### PR TITLE
Added option to include 'All member' when place hierarchy

### DIFF
--- a/pivot4j-core/src/main/java/org/pivot4j/transform/PlaceHierarchiesOnAxes.java
+++ b/pivot4j-core/src/main/java/org/pivot4j/transform/PlaceHierarchiesOnAxes.java
@@ -21,16 +21,16 @@ import org.olap4j.metadata.Hierarchy;
  * <li>The GUI will examine the result of the olap query to find out which
  * hierarchies are currently displayed on what axes. It will use
  * Axis.getHierarchies() for this.</li>
- * 
+ *
  * <li>Then it will find out what Hierarchies exist by calling
  * OlapModel.getDimensions() and Dimension.getHierarchies().</li>
- * 
+ *
  * <li>The Information will be presented to the user and he will be allowed to
  * change the mapping between axes and hierarchies.</li>
- * 
+ *
  * <li>For every Hierarchy that the user selected for display on an axis, the
  * GUI will call createMemberExpression().</li>
- * 
+ *
  * <li>For each axis the system will build the the array of memberExpressions
  * and call setAxis once.</li>
  * </ul>
@@ -45,9 +45,22 @@ public interface PlaceHierarchiesOnAxes extends Transform {
 	 * @param expandAllMember
 	 *            If this flag is set and an "All" member is put onto an axis,
 	 *            the children of the All member will be added as well.
+	 * @param includeAllMember
+	 * 			  If this flag is set and an "All" member is put onto axis,
+	 * 			  include Union (All + Children). If it's false, only includes Children.
 	 */
-	void placeHierarchies(Axis axis, List<Hierarchy> hierarchies,
-			boolean expandAllMember);
+	void placeHierarchies(Axis axis, List<Hierarchy> hierarchies, boolean expandAllMember, boolean includeAllMember);
+
+	/**
+	 * @param axis
+	 *            The target axis
+	 * @param hierarchies
+	 *            The hierarchies to put
+	 * @param expandAllMember
+	 *            If this flag is set and an "All" member is put onto an axis,
+	 *            the children of the All member will be added as well.
+	 */
+	void placeHierarchies(Axis axis, List<Hierarchy> hierarchies, boolean expandAllMember);
 
 	/**
 	 * @param axis
@@ -60,7 +73,24 @@ public interface PlaceHierarchiesOnAxes extends Transform {
 	 *            than ZERO will put the hierarchy at the end of the axis.
 	 */
 	void addHierarchy(Axis axis, Hierarchy hierarchy, boolean expandAllMember,
-			int position);
+					  int position);
+
+	/**
+	 * @param axis
+	 *            The target axis
+	 * @param hierarchy
+	 *            The hierarchy to add
+	 * @param expandAllMember
+	 *
+	 * @param includeAllMember
+	 * 			  If this flag is set and an "All" member is put onto axis,
+	 * 			  include Union (All + Children). If it's false, only includes Children.
+	 * @param position
+	 *            The position index where to add the hierarchy. Any value less
+	 *            than ZERO will put the hierarchy at the end of the axis.
+	 */
+	void addHierarchy(Axis axis, Hierarchy hierarchy, boolean expandAllMember, boolean includeAllMember,
+					  int position);
 
 	/**
 	 * @param axis
@@ -83,7 +113,7 @@ public interface PlaceHierarchiesOnAxes extends Transform {
 	/**
 	 * Collects all hierarchies on a given axis in the result. If no hierarchies
 	 * are visible, it returns an empty list.
-	 * 
+	 *
 	 * @param axis
 	 *            the axis to use
 	 * @return A list of hierarchies

--- a/pivot4j-core/src/main/java/org/pivot4j/transform/PlaceHierarchiesOnAxes.java
+++ b/pivot4j-core/src/main/java/org/pivot4j/transform/PlaceHierarchiesOnAxes.java
@@ -8,10 +8,10 @@
  */
 package org.pivot4j.transform;
 
-import java.util.List;
-
 import org.olap4j.Axis;
 import org.olap4j.metadata.Hierarchy;
+
+import java.util.List;
 
 /**
  * Allows to place hierarchies on the visible query axes.
@@ -21,16 +21,16 @@ import org.olap4j.metadata.Hierarchy;
  * <li>The GUI will examine the result of the olap query to find out which
  * hierarchies are currently displayed on what axes. It will use
  * Axis.getHierarchies() for this.</li>
- *
+ * <p>
  * <li>Then it will find out what Hierarchies exist by calling
  * OlapModel.getDimensions() and Dimension.getHierarchies().</li>
- *
+ * <p>
  * <li>The Information will be presented to the user and he will be allowed to
  * change the mapping between axes and hierarchies.</li>
- *
+ * <p>
  * <li>For every Hierarchy that the user selected for display on an axis, the
  * GUI will call createMemberExpression().</li>
- *
+ * <p>
  * <li>For each axis the system will build the the array of memberExpressions
  * and call setAxis once.</li>
  * </ul>
@@ -38,75 +38,55 @@ import org.olap4j.metadata.Hierarchy;
 public interface PlaceHierarchiesOnAxes extends Transform {
 
 	/**
-	 * @param axis
-	 *            The target axis
-	 * @param hierarchies
-	 *            The hierarchies to put
-	 * @param expandAllMember
-	 *            If this flag is set and an "All" member is put onto an axis,
-	 *            the children of the All member will be added as well.
-	 * @param includeAllMember
-	 * 			  If this flag is set and an "All" member is put onto axis,
-	 * 			  include Union (All + Children). If it's false, only includes Children.
+	 * @param axis             The target axis
+	 * @param hierarchies      The hierarchies to put
+	 * @param expandAllMember  If this flag is set and an "All" member is put onto an axis,
+	 *                         the children of the All member will be added as well.
+	 * @param includeAllMember If this flag is set and an "All" member is put onto axis,
+	 *                         include Union (All + Children). If it's false, only includes Children.
 	 */
 	void placeHierarchies(Axis axis, List<Hierarchy> hierarchies, boolean expandAllMember, boolean includeAllMember);
 
 	/**
-	 * @param axis
-	 *            The target axis
-	 * @param hierarchies
-	 *            The hierarchies to put
-	 * @param expandAllMember
-	 *            If this flag is set and an "All" member is put onto an axis,
-	 *            the children of the All member will be added as well.
+	 * @param axis            The target axis
+	 * @param hierarchies     The hierarchies to put
+	 * @param expandAllMember If this flag is set and an "All" member is put onto an axis,
+	 *                        the children of the All member will be added as well.
 	 */
 	void placeHierarchies(Axis axis, List<Hierarchy> hierarchies, boolean expandAllMember);
 
 	/**
-	 * @param axis
-	 *            The target axis
-	 * @param hierarchy
-	 *            The hierarchy to add
+	 * @param axis            The target axis
+	 * @param hierarchy       The hierarchy to add
 	 * @param expandAllMember
-	 * @param position
-	 *            The position index where to add the hierarchy. Any value less
-	 *            than ZERO will put the hierarchy at the end of the axis.
+	 * @param position        The position index where to add the hierarchy. Any value less
+	 *                        than ZERO will put the hierarchy at the end of the axis.
 	 */
 	void addHierarchy(Axis axis, Hierarchy hierarchy, boolean expandAllMember,
 					  int position);
 
 	/**
-	 * @param axis
-	 *            The target axis
-	 * @param hierarchy
-	 *            The hierarchy to add
+	 * @param axis             The target axis
+	 * @param hierarchy        The hierarchy to add
 	 * @param expandAllMember
-	 *
-	 * @param includeAllMember
-	 * 			  If this flag is set and an "All" member is put onto axis,
-	 * 			  include Union (All + Children). If it's false, only includes Children.
-	 * @param position
-	 *            The position index where to add the hierarchy. Any value less
-	 *            than ZERO will put the hierarchy at the end of the axis.
+	 * @param includeAllMember If this flag is set and an "All" member is put onto axis,
+	 *                         include Union (All + Children). If it's false, only includes Children.
+	 * @param position         The position index where to add the hierarchy. Any value less
+	 *                         than ZERO will put the hierarchy at the end of the axis.
 	 */
 	void addHierarchy(Axis axis, Hierarchy hierarchy, boolean expandAllMember, boolean includeAllMember,
 					  int position);
 
 	/**
-	 * @param axis
-	 *            The target axis
-	 * @param hierarchy
-	 *            The hierarchy to remove
+	 * @param axis      The target axis
+	 * @param hierarchy The hierarchy to remove
 	 */
 	void removeHierarchy(Axis axis, Hierarchy hierarchy);
 
 	/**
-	 * @param axis
-	 *            The target axis
-	 * @param hierarchy
-	 *            The hierarchy to move
-	 * @param position
-	 *            New hierarchy position
+	 * @param axis      The target axis
+	 * @param hierarchy The hierarchy to move
+	 * @param position  New hierarchy position
 	 */
 	void moveHierarchy(Axis axis, Hierarchy hierarchy, int position);
 
@@ -114,8 +94,7 @@ public interface PlaceHierarchiesOnAxes extends Transform {
 	 * Collects all hierarchies on a given axis in the result. If no hierarchies
 	 * are visible, it returns an empty list.
 	 *
-	 * @param axis
-	 *            the axis to use
+	 * @param axis the axis to use
 	 * @return A list of hierarchies
 	 */
 	List<Hierarchy> findVisibleHierarchies(Axis axis);

--- a/pivot4j-core/src/main/java/org/pivot4j/transform/impl/PlaceHierarchiesOnAxesImpl.java
+++ b/pivot4j-core/src/main/java/org/pivot4j/transform/impl/PlaceHierarchiesOnAxesImpl.java
@@ -8,10 +8,6 @@
  */
 package org.pivot4j.transform.impl;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import org.olap4j.Axis;
 import org.olap4j.OlapConnection;
 import org.olap4j.OlapException;
@@ -31,6 +27,10 @@ import org.pivot4j.transform.PlaceHierarchiesOnAxes;
 import org.pivot4j.util.OlapUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class PlaceHierarchiesOnAxesImpl extends AbstractTransform implements
 		PlaceHierarchiesOnAxes {
@@ -52,7 +52,7 @@ public class PlaceHierarchiesOnAxesImpl extends AbstractTransform implements
 	}
 	/**
 	 * @see org.pivot4j.transform.PlaceHierarchiesOnAxes#placeHierarchies(org.olap4j.Axis,
-	 *      java.util.List, boolean, boolean)
+	 * java.util.List, boolean, boolean)
 	 */
 	public void placeHierarchies(Axis axis, List<Hierarchy> hierarchies,
 								 boolean expandAllMember, boolean includeAllMember) {
@@ -100,7 +100,7 @@ public class PlaceHierarchiesOnAxesImpl extends AbstractTransform implements
 
 	/**
 	 * @see org.pivot4j.transform.PlaceHierarchiesOnAxes#addHierarchy(org.olap4j.Axis,
-	 *      org.olap4j.metadata.Hierarchy, boolean, int)
+	 * org.olap4j.metadata.Hierarchy, boolean, int)
 	 */
 	@Override
 	public void addHierarchy(Axis axis, Hierarchy hierarchy,
@@ -110,7 +110,7 @@ public class PlaceHierarchiesOnAxesImpl extends AbstractTransform implements
 
 	/**
 	 * @see org.pivot4j.transform.PlaceHierarchiesOnAxes#addHierarchy(org.olap4j.Axis,
-	 *      org.olap4j.metadata.Hierarchy, boolean, boolean, int)
+	 * org.olap4j.metadata.Hierarchy, boolean, boolean, int)
 	 */
 	@Override
 	public void addHierarchy(Axis axis, Hierarchy hierarchy,
@@ -135,7 +135,7 @@ public class PlaceHierarchiesOnAxesImpl extends AbstractTransform implements
 
 	/**
 	 * @see org.pivot4j.transform.PlaceHierarchiesOnAxes#moveHierarchy(org.olap4j
-	 *      .Axis, org.olap4j.metadata.Hierarchy, int)
+	 * .Axis, org.olap4j.metadata.Hierarchy, int)
 	 */
 	@Override
 	public void moveHierarchy(Axis axis, Hierarchy hierarchy, int position) {
@@ -170,7 +170,7 @@ public class PlaceHierarchiesOnAxesImpl extends AbstractTransform implements
 
 	/**
 	 * @see org.pivot4j.transform.PlaceHierarchiesOnAxes#removeHierarchy(org
-	 *      .olap4j.Axis, org.olap4j.metadata.Hierarchy)
+	 * .olap4j.Axis, org.olap4j.metadata.Hierarchy)
 	 */
 	@Override
 	public void removeHierarchy(Axis axis, Hierarchy hierarchy) {
@@ -191,7 +191,7 @@ public class PlaceHierarchiesOnAxesImpl extends AbstractTransform implements
 
 	/**
 	 * @see org.pivot4j.transform.PlaceHierarchiesOnAxes#findVisibleHierarchies
-	 *      (org.olap4j.Axis)
+	 * (org.olap4j.Axis)
 	 */
 	@Override
 	public List<Hierarchy> findVisibleHierarchies(Axis axis) {

--- a/pivot4j-core/src/main/java/org/pivot4j/transform/impl/PlaceHierarchiesOnAxesImpl.java
+++ b/pivot4j-core/src/main/java/org/pivot4j/transform/impl/PlaceHierarchiesOnAxesImpl.java
@@ -42,22 +42,26 @@ public class PlaceHierarchiesOnAxesImpl extends AbstractTransform implements
 	 * @param connection
 	 */
 	public PlaceHierarchiesOnAxesImpl(QueryAdapter queryAdapter,
-			OlapConnection connection) {
+									  OlapConnection connection) {
 		super(queryAdapter, connection);
 	}
 
+	public void placeHierarchies(Axis axis, List<Hierarchy> hierarchies,
+								 boolean expandAllMember) {
+		placeHierarchies(axis, hierarchies, expandAllMember, true);
+	}
 	/**
 	 * @see org.pivot4j.transform.PlaceHierarchiesOnAxes#placeHierarchies(org.olap4j.Axis,
-	 *      java.util.List, boolean)
+	 *      java.util.List, boolean, boolean)
 	 */
 	public void placeHierarchies(Axis axis, List<Hierarchy> hierarchies,
-			boolean expandAllMember) {
+								 boolean expandAllMember, boolean includeAllMember) {
 		QueryAdapter adapter = getQueryAdapter();
 
 		List<Exp> memberExpressions = new ArrayList<Exp>();
 		for (Hierarchy hierarchy : hierarchies) {
 			memberExpressions.add(createMemberExpression(hierarchy,
-					expandAllMember));
+					expandAllMember, includeAllMember));
 		}
 
 		Quax quax = adapter.getQuax(axis);
@@ -100,7 +104,17 @@ public class PlaceHierarchiesOnAxesImpl extends AbstractTransform implements
 	 */
 	@Override
 	public void addHierarchy(Axis axis, Hierarchy hierarchy,
-			boolean expandAllMember, int position) {
+							 boolean expandAllMember, int position) {
+		addHierarchy(axis, hierarchy, expandAllMember, true, position);
+	}
+
+	/**
+	 * @see org.pivot4j.transform.PlaceHierarchiesOnAxes#addHierarchy(org.olap4j.Axis,
+	 *      org.olap4j.metadata.Hierarchy, boolean, boolean, int)
+	 */
+	@Override
+	public void addHierarchy(Axis axis, Hierarchy hierarchy,
+							 boolean expandAllMember, boolean includeAllMember, int position) {
 		List<Hierarchy> hierarchies = findVisibleHierarchies(axis);
 
 		if (hierarchies.contains(hierarchy)) {
@@ -116,7 +130,7 @@ public class PlaceHierarchiesOnAxesImpl extends AbstractTransform implements
 			hierarchies.add(position, hierarchy);
 		}
 
-		placeHierarchies(axis, hierarchies, expandAllMember);
+		placeHierarchies(axis, hierarchies, expandAllMember, includeAllMember);
 	}
 
 	/**
@@ -199,7 +213,7 @@ public class PlaceHierarchiesOnAxesImpl extends AbstractTransform implements
 	 * @return
 	 */
 	protected Exp createMemberExpression(Hierarchy hierarchy,
-			boolean expandAllMember) {
+										 boolean expandAllMember, boolean includeAllMember) {
 		// if the query does not contain the hierarchy,
 		// just return the highest level
 		QueryAdapter adapter = getQueryAdapter();
@@ -209,7 +223,7 @@ public class PlaceHierarchiesOnAxesImpl extends AbstractTransform implements
 		if (quax == null) {
 			adapter.getCurrentMdx(true);
 			// the hierarchy was not found on any axis
-			return topLevelMembers(hierarchy, expandAllMember);
+			return topLevelMembers(hierarchy, expandAllMember, includeAllMember);
 			// return top level members of the hierarchy
 		}
 
@@ -222,12 +236,12 @@ public class PlaceHierarchiesOnAxesImpl extends AbstractTransform implements
 
 	/**
 	 * TODO Merge with {@link QuaxUtil#topLevelMembers(Hierarchy, boolean)}
-	 * 
+	 *
 	 * @param hierarchy
 	 * @param expandAllMember
 	 * @return
 	 */
-	protected Exp topLevelMembers(Hierarchy hierarchy, boolean expandAllMember) {
+	protected Exp topLevelMembers(Hierarchy hierarchy, boolean expandAllMember, boolean includeAllMember) {
 		try {
 			if (hierarchy.hasAll()) {
 				// an "All" member is present -get it
@@ -260,20 +274,29 @@ public class PlaceHierarchiesOnAxesImpl extends AbstractTransform implements
 
 					// must expand
 					// create Union({AllMember}, AllMember.children)
-					Exp allExp = new MemberExp(allMember);
+					if (includeAllMember) {
+						Exp allExp = new MemberExp(allMember);
 
-					FunCall allSet = new FunCall("{}", Syntax.Braces);
-					allSet.getArgs().add(allExp);
+						FunCall allSet = new FunCall("{}", Syntax.Braces);
+						allSet.getArgs().add(allExp);
 
-					FunCall mAllChildren = new FunCall("Children",
-							Syntax.Property);
-					mAllChildren.getArgs().add(allExp);
+						FunCall mAllChildren = new FunCall("Children",
+								Syntax.Property);
+						mAllChildren.getArgs().add(allExp);
 
-					FunCall union = new FunCall("Union", Syntax.Function);
-					union.getArgs().add(allSet);
-					union.getArgs().add(mAllChildren);
+						FunCall union = new FunCall("Union", Syntax.Function);
+						union.getArgs().add(allSet);
+						union.getArgs().add(mAllChildren);
 
-					return union;
+						return union;
+					} else {
+						Exp allExp = new MemberExp(allMember);
+
+						FunCall mAllChildren = new FunCall("Children",
+								Syntax.Property);
+						mAllChildren.getArgs().add(allExp);
+						return mAllChildren;
+					}
 				}
 			}
 

--- a/pivot4j-core/src/test/java/org/pivot4j/transform/impl/PlaceHierarchiesOnAxesImplIT.java
+++ b/pivot4j-core/src/test/java/org/pivot4j/transform/impl/PlaceHierarchiesOnAxesImplIT.java
@@ -8,19 +8,17 @@
  */
 package org.pivot4j.transform.impl;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.Test;
 import org.olap4j.Axis;
 import org.olap4j.metadata.Cube;
 import org.olap4j.metadata.Hierarchy;
 import org.pivot4j.transform.PlaceHierarchiesOnAxes;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
 
 public class PlaceHierarchiesOnAxesImplIT extends
 		AbstractTransformTestCase<PlaceHierarchiesOnAxes> {

--- a/pivot4j-core/src/test/java/org/pivot4j/transform/impl/PlaceHierarchiesOnAxesImplIT.java
+++ b/pivot4j-core/src/test/java/org/pivot4j/transform/impl/PlaceHierarchiesOnAxesImplIT.java
@@ -95,6 +95,31 @@ public class PlaceHierarchiesOnAxesImplIT extends
 	}
 
 	@Test
+	public void testExpandAllMembersExcludingAll() {
+		PlaceHierarchiesOnAxes transform = getTransform();
+
+		Cube cube = getPivotModel().getCube();
+
+		Hierarchy promotionMedia = cube.getHierarchies().get("Promotion Media");
+		Hierarchy product = cube.getHierarchies().get("Product");
+
+		List<Hierarchy> hierarchies = new ArrayList<Hierarchy>(2);
+		hierarchies.add(promotionMedia);
+		hierarchies.add(product);
+
+		transform.placeHierarchies(Axis.ROWS, hierarchies, true, false);
+
+		assertThat(
+				"Unexpected MDX query after set hierarchies on axis",
+				getPivotModel().getCurrentMdx(),
+				is(equalTo("SELECT {[Measures].[Unit Sales], [Measures].[Store Cost], [Measures].[Store Sales]} ON COLUMNS, "
+						+ "CrossJoin([Promotion Media].[All Media].Children, "
+						+ "{[Product].[All Products], [Product].[Drink], [Product].[Food], [Product].[Non-Consumable]}) ON ROWS FROM [Sales]")));
+
+		getPivotModel().getCellSet();
+	}
+
+	@Test
 	public void testAddHierarchyAtIndexMinusOne() {
 		PlaceHierarchiesOnAxes transform = getTransform();
 


### PR DESCRIPTION
I'm currently working with mondrian dsp capacities to filter output results based on security criterias.

In this case, I've found the necessity to, when I add a Hierarchy and I want to include all children,  prevent include 'All' field', because security filtering does that the result displayed is wrong.

I modified PlaceHierarchyTransform to allow to specify a flag to control this.